### PR TITLE
Make bottom panel remember adjusted height

### DIFF
--- a/src/components/Tabs.vue
+++ b/src/components/Tabs.vue
@@ -74,9 +74,10 @@
 </template>
 
 <script>
-  import {mapGetters} from 'eva.js'
+  import {mapGetters, mapActions} from 'eva.js'
   import highlight from '../utils/highlight'
   import {preventSelectStart, preventSelectStop} from '../utils/prevent-select'
+  import {defaultBottomPanelHeight} from '../models/layout'
 
   export default {
     name: 'console',
@@ -91,7 +92,8 @@
     computed: {
       ...mapGetters([
         'logs',
-        'bottomPanelExpanded'
+        'bottomPanelExpanded',
+        'bottomPanelHeight'
       ]),
       highlightedExample() {
         if (!this.example) return
@@ -101,7 +103,7 @@
     data() {
       return {
         active: this.readme ? 'readme' : 'console',
-        tabHeight: 280,
+        tabHeight: defaultBottomPanelHeight,
         startY: null,
         originalHeight: null,
         resizing: false
@@ -113,9 +115,12 @@
         min: this.$refs.header.getBoundingClientRect().height,
         max: this.$refs.panel.parentNode.getBoundingClientRect().height
       }
+      console.log(this.tabHeight)
+      this.tabHeight = this.bottomPanelHeight
     },
 
     methods: {
+      ...mapActions(['setBottomPanelHeight']),
       handleMouseDown({clientY}) {
         this.resizing = true
         this.startY = clientY
@@ -134,6 +139,7 @@
 
       handleMouseUp() {
         this.resizing = false
+        this.setBottomPanelHeight(this.tabHeight)
         document.removeEventListener('mousemove', this.handleMouseMove)
         document.removeEventListener('mouseup', this.handleMouseUp)
         preventSelectStop()

--- a/src/models/layout.js
+++ b/src/models/layout.js
@@ -1,12 +1,16 @@
 export const TOGGLE_LEFT_PANEL = 'TOGGLE_LEFT_PANEL'
 export const TOGGLE_BOTTOM_PANEL = 'TOGGLE_BOTTOM_PANEL'
 export const TOGGLE_ALL_PANELS = 'TOGGLE_ALL_PANELS'
+export const SET_BOTTOM_PANEL_HEIGHT = 'SET_BOTTOM_PANEL_HEIGHT'
+
+export const defaultBottomPanelHeight = 280;
 
 export default {
   name: 'layout',
   state: {
     leftPanelExpanded: true,
-    bottomPanelExpanded: true
+    bottomPanelExpanded: true,
+    bottomPanelHeight: defaultBottomPanelHeight
   },
   mutations: {
     TOGGLE_LEFT_PANEL(state) {
@@ -14,6 +18,9 @@ export default {
     },
     TOGGLE_BOTTOM_PANEL(state) {
       state.bottomPanelExpanded = !state.bottomPanelExpanded
+    },
+    SET_BOTTOM_PANEL_HEIGHT(state, payload) {
+      state.bottomPanelHeight = payload || defaultBottomPanelHeight
     }
   },
   actions: {
@@ -35,6 +42,9 @@ export default {
           commit(TOGGLE_BOTTOM_PANEL)
         }
       }
+    },
+    setBottomPanelHeight({commit}, payload) {
+      commit(SET_BOTTOM_PANEL_HEIGHT, payload)
     }
   },
   getters: {
@@ -43,6 +53,9 @@ export default {
     },
     bottomPanelExpanded(state) {
       return state.bottomPanelExpanded
+    },
+    bottomPanelHeight(state) {
+      return state.bottomPanelHeight
     }
   }
 }

--- a/src/models/layout.js
+++ b/src/models/layout.js
@@ -3,7 +3,7 @@ export const TOGGLE_BOTTOM_PANEL = 'TOGGLE_BOTTOM_PANEL'
 export const TOGGLE_ALL_PANELS = 'TOGGLE_ALL_PANELS'
 export const SET_BOTTOM_PANEL_HEIGHT = 'SET_BOTTOM_PANEL_HEIGHT'
 
-export const defaultBottomPanelHeight = 280;
+export const defaultBottomPanelHeight = 280
 
 export default {
   name: 'layout',


### PR DESCRIPTION
Fixes #17. 

Basically uses vuex to store adjusted height so that it's remembered when switching between playspots. 
