### PR TITLE
Add background color to the play-tabs

### DIFF
--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -123,6 +123,6 @@
     font-size: 12px;
   }
   .play-tabs {
-    background-color: rgb(247, 247, 247);
+    background-color: white;
   }
 </style>

--- a/src/components/AppMain.vue
+++ b/src/components/AppMain.vue
@@ -122,4 +122,7 @@
     border-bottom: 1px solid;
     font-size: 12px;
   }
+  .play-tabs {
+    background-color: rgb(247, 247, 247);
+  }
 </style>


### PR DESCRIPTION
The iframe may has non-white color, and made contents in bottom not able to be read.

This is what happens before this fix:
![image](https://cloud.githubusercontent.com/assets/58912/22596988/51edfec0-ea60-11e6-99d2-e8800ccce7bd.png)

After:
![image](https://cloud.githubusercontent.com/assets/58912/22597002/5a1531a4-ea60-11e6-9ee9-70cce8fbd138.png)
